### PR TITLE
README: add missing pyqtwebengine module

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ On most other distributions, you'll want to run it directly:
 # For Ubuntu/Debian testing derivates:
 $ sudo apt install python3-pip git openjdk-9-jre
 
-$ sudo pip3 install protobuf pyqt5 requests websocket-client
+$ sudo pip3 install protobuf pyqt5 pyqtwebengine requests websocket-client
 
 $ git clone https://github.com/marin-m/pbtk
 $ cd pbtk


### PR DESCRIPTION
pbtk uses PyQtWebEngine, which has been moved from pyqt5 to a new module.

See https://stackoverflow.com/a/54947671