### PR TITLE
Fixed incompatible reserved being put on the same line

### DIFF
--- a/utils/descpb_to_proto.py
+++ b/utils/descpb_to_proto.py
@@ -82,8 +82,8 @@ def parse_msg(desc, scopes, syntax):
             out += wrap_block('oneof', blocks.pop('_oneof_%d' % index), oneof)
         
         out += fmt_ranges('extensions', desc.extension_range)
-        out += fmt_ranges('reserved', [*desc.reserved_range, *desc.reserved_name])
-    
+        out += fmt_ranges('reserved', desc.reserved_range)
+        out += fmt_ranges('reserved', desc.reserved_name)
     else:
         for service in desc.service:
             out2 = ''


### PR DESCRIPTION
From https://protobuf.dev/programming-guides/proto3/#reserved-field-names
`Note that you can’t mix field names and field numbers in the same reserved statement.`


Sometimes the following would be generated:
```proto
message MyMessage {
  required int32 a = 1;
  required int32 b = 2;
  required int32 c = 4;

  reserved 3, "config";
}
```

With this patch it will generate instead
```proto
message AccessLog {
  required int32 a = 1;
  required int32 b = 2;
  required int32 c = 4;

  reserved 3;
  reserved "config";
}
```